### PR TITLE
Suggested edits to the gather paper, and a few inline comments

### DIFF
--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -14,7 +14,7 @@ the problem of finding a minimum collection of reference genomes
 that "cover" the known k-mers in a metagenome. We implement a greedy
 approximate solution using  _Scaled MinHash_ sketches, and evaluate
 its accuracy in taxonomic assignment using a CAMI community benchmark.
-Finally, we show that the minimum set cover can be used for accurate read
+Finally, we show that genomes in the minimum set cover can be used for accurate read
 mapping.
 sourmash is available as open source under the
 BSD 3-Clause license at github.com/dib-lab/sourmash/.

--- a/content/02.introduction.md
+++ b/content/02.introduction.md
@@ -7,7 +7,7 @@ Compositional analysis of shotgun metagenome samples has the goal of
 identifying what functions and taxonomic units are present in the
 data.  Function and taxonomy is typically inferred from available
 reference genomes and gene catalogs, via direct genomic alignment
-(cite biobakery, MEGAN-LR), gene search (cite mmseqs, etc.), or k-mer matches
+(cite biobakery, MEGAN-LR), gene search (cite mmseqs, eggnog etc.), or k-mer matches
 (Kraken).  For many of these methods, the substantial increase in the
 number of available reference genomes (1.1m in GenBank as of XYZ)
 presents a significant practical obstacle to comprehensive

--- a/content/03.results.md
+++ b/content/03.results.md
@@ -87,7 +87,7 @@ a match is chosen at random.
 
 In Figure @fig:gather0, we show the results of this iterative
 decomposition of the mock metagenome from
-[@doi:10.1111/1462-2920.12086], into constituent genome matches.  The
+[@doi:10.1111/1462-2920.12086] (Table @tbl:genbank-cover, row 2), into constituent genome matches.  The
 high rank (early) matches reflect large and/or mostly-covered genomes
 with high containment, while later matches reflect smaller genomes,
 lower-covered genomes, and/or genomes with substantial overlap with
@@ -190,6 +190,9 @@ between the true and predicted abundances at a specific taxonomic
 rank) -->
 the highest number of true positives and the lowest number of
 false positives.
+<!-- TR: it looks like mOTU has hte lowest L1-norm, not sourmash? -->
+<!-- runtimes/memory are mentioned in the discussion saying they're in the appendix,
+I think it would be nice to mention that they're in the appendix here -->
 
 <!--
 | Taxonomic binner                | Time (hh:mm) | Memory (kbytes) |
@@ -278,20 +281,20 @@ with overlap in the query metagenome (see Methods).
 
 We find many genomes with large overlaps for each metagenome, due to
 the redundancy of the reference database. For example, `zymo mock`
-contains a *Salmonella* genome, and there are over 200,000 Salmonella
-genomes that match to it in Genbank. Likewise, `gut real`
+contains a *Salmonella* genome, and there are over 200,000 *Salmonella*
+genomes that match to it in GenBank. Likewise, `gut real`
 matches to over 75,000 *E. coli* genomes in GenBank.  Since neither
 `podar mock` nor `oil well real` contain genomes from species with
-substantial representation in genbank, they yield many fewer total
+substantial representation in GenBank, they yield many fewer total
 overlapping genomes.
 
-However, regardless of the number of genomes in the database with substantial
+Regardless of the number of genomes in the database with substantial
 overlap, the
 estimated _minimum_ collection of genomes is always much smaller than the
 number of genomes with overlaps. In
 the cases where the k-mers in the metagenome are mostly identified,
 this is because of database redundancy: e.g. in the case of `zymo
-mock`, the min-set-cov algorithm chooses only one Salmonella genome
+mock`, the min-set-cov algorithm chooses only one *Salmonella* genome
 from the 200,000+ available. Conversely, in the case of `oil well real`,
 much of the sample is not identified,
 suggesting that the small size of the covering set is because much
@@ -321,9 +324,9 @@ reads to the entire GenBank database. (CTB: check centrifuge.)
 
 Figure @fig:mapping compares hash assignment rates
 and mapping rates for the four evaluation metagenomes in Table
-@tbl:genbank-cover. Broadly speaking, we see that k-mer based
+@tbl:genbank-cover. Broadly speaking, we see that k-mer-based
 estimates of metagenome composition align closely with the number of
-bases covered by mapped reads: the y axis has not been re-scaled, so hash matches and read mapping correspond well. This suggests that the k-mer based min-set-cov
+bases covered by mapped reads: the y axis has not been re-scaled, so hash matches and read mapping correspond well. This suggests that the k-mer-based min-set-cov
 approach effectively selects reference genomes for metagenome read mapping.
 
 For mock metagenomes (panels X and Y), there appears to be a close

--- a/content/04.discussion.md
+++ b/content/04.discussion.md
@@ -34,7 +34,7 @@ operations - including all of the operations used here -
 without needing to revisit the original data set. This is in contrast
 to MinHash, which requires auxiliary data structures for many
 operations - most especially, containment operations (cite CMash and
-mash screen).  Thus Scaled MinHash sketches serve as distributed
+mash screen).  Thus _Scaled MinHash_ sketches serve as distributed
 compressed indices for the original content for a much broader range
 of operations than MinHash.
 
@@ -46,7 +46,7 @@ properties, but this is not the case for MinHash, since
 after $n$ values are selected any displacement caused by new data can
 invalidate previous calculations.
 
-Scaled MinHash also directly supports the addition and subtraction of
+_Scaled MinHash_ also directly supports the addition and subtraction of
 hash values from a sketch, allowing post-processing and filtering without
 revisiting the original data set. This includes unions and intersections.
 Although possible for MinHash, in practice this requires
@@ -64,7 +64,7 @@ MinHash.  These operations can be done in _Scaled MinHash_ without
 auxiliary data structures.
 
 Another useful operation available on _Scaled MinHash_ sketches is
-*downsampling*: the contiguous value range for Scaled MinHash sketches
+*downsampling*: the contiguous value range for _Scaled MinHash_ sketches
 allows deriving MinHash sketches from _Scaled MinHash_ sketches
 whenever the number of hashes in the _Scaled MinHash_ sketch is equal
 to or greater than $n$, as long as the same hashing scheme is used.
@@ -128,7 +128,7 @@ as Diamond use read mapping to genomes or read alignment to
 gene sequences in order to assign taxonomy and function (cite). These
 approaches typically focus on assigning *individual* k-mers or reads.
 In contrast, here we analyze the entire collection of k-mers and
-assigns them _in aggregate_ to the _best_ genome match, and then repeat
+assign them _in aggregate_ to the _best_ genome match, and then repeat
 until no matches remain.
 
 The resulting metagenome cover can then be used as inputs for further
@@ -239,7 +239,7 @@ overlapping genomes, that is, *all* the genomes in column 2 of Table
 @tbl:genbank-cover. For example, a hierarchical approach could be
 taken to first identify the full list of overlapping genomes, followed
 by a higher resolution approach to identify a specific subset of
-matcheing genomes.
+matching genomes.
 
 ## Opportunities for future improvement of min-set-cov
 
@@ -250,7 +250,7 @@ Implementing min-set-cov on top of _Scaled MinHash_ means
 that there is a loss of resolution when choosing between very closely
 related genomes, because the set of hashes chosen may not discriminate
 between them.  Likewise, the potentially very large size of the sketches
-may inhibit the application of this approach to metagenomes.
+may inhibit the application of this approach to very large metagenomes.
 
 These limitations are not intrinsic to min-set-cov, however; 
 any data structure supporting both the _containment_ $C(A, B) =


### PR DESCRIPTION
I'm including suggested edits in this PR. Most are typos, some add a little clarification, and I added one or two comments inline. I'm also going to provide some comments here in this PR. 

Overall, I really loved the title and the discussion of this paper. I think the set of results provided are the right set, and I like the organization of the results section. I think the paper is fairly lean though. In particular, I think the introduction could use more contextualizing information, that the results section should have a summary first paragraph (many of the details of which are already covered in the intro, and could be moved here), and the discussion should have a summary first paragraph. Lastly, I think that while there are enough references to sourmash and its capabilities, we don't reference specific commands enough (e.g., `gather`), so that obfuscates how to actually use the thing from a user. 

I feel pretty strongly that the discussion needs a baby summary intro paragraph, but could be convinced that the intro and results don't need to change, depending on the intended audience of the paper. But without these things, the audience of the paper does _not_ overlap with the intended users of the tools very much, which is a bit of a missed opportunity to put this tool into the hands of people who could use it most.

Other specific comments:
+ Does Figure 1 need to be smaller? I think a coord flip would help it take up about ~half the space it does. The axis fonts are also very smol
+ For the sentence, "Note that in cases where equivalent matches are available at a particular rank, a match is chosen at random.": Should we mention that it's easy to return all matches (e.g. with search)? Or that the software is not algorithmically limited to do this, and that it was just a design decision?
+ Is the database consistent through the results? I guess the date of the GenBank database will probably be added in the methods?
+ For the section, "Minimum metagenome covers provide representative genomes for mapping", have we/should we show that gather picks the genomes that maps the most reads over all other closely related genomes in GenBank? Maybe not using e.g. salmonella, but maybe with a genome that has a few hundred other genomes of the same species?
+ The italics on _Scaled MinHash_ and _MinHash_ are inconsistent. I think I fixed all of the Scaled MinHash ones, but I wasn't sure if MinHash was supposed to be italicized or not so I just left it.
+ Figure 5 is titled, "Hash-based decomposition of a metagenome...". Could we change it to `Hash-based k-mer decomposition of a metagenome..."?
